### PR TITLE
update tap_linux.go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module cloaq
 
 go 1.25.0
+
+require golang.org/x/sys v0.41.0 // direct

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
+golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=

--- a/src/main.go
+++ b/src/main.go
@@ -1,13 +1,13 @@
 package main
 
 import (
-	"fmt"
+	"log"
 	"os"
 )
 
 func main() {
 	if len(os.Args) < 2 {
-		fmt.Println("Usage: cloaq <command>")
+		log.Println("Usage: cloaq <command>")
 		return
 	}
 
@@ -19,19 +19,33 @@ func main() {
 	case "help":
 		helpCommand()
 	default:
-		fmt.Println("Unknown command:", os.Args[1])
+		log.Println("Unknown command:", os.Args[1])
 	}
 }
 
 func runCommand() {
-	fmt.Println("Running Cloaq")
+	if os.Geteuid() != 0 {
+		log.Fatal("Run as root") // privileged kernel networking operations
+	}
+	log.Println("Running Cloaq")
 
+	// Create TUN interface
+	tunFD := NewTUN("tun0")
+
+	// Example static routes
+	AddRoute("2001:db8:1::/64", "eth0")
+	AddRoute("2001:db8:2::/64", "eth1")
+
+	log.Println("IPv6 TUN gateway created")
+
+	// CreateRouter(tunFD) to listen and forward packets to another nodes
+	CreateIPv6PacketListener(tunFD)
 }
 
 func helpCommand() {
-	fmt.Println("help text")
+	log.Println("help text")
 }
 
 func settingsCommand() {
-	fmt.Println("settings text")
+	log.Println("settings text")
 }

--- a/src/tap_linux.go
+++ b/src/tap_linux.go
@@ -1,8 +1,18 @@
 package main
 
 import (
+	"log"
+	"net"
 	"os"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
 )
+
+/*
+	we're gonna have to disable
+*/
 
 const (
 	// To get L3 interface
@@ -16,16 +26,141 @@ const (
 )
 
 type interfaceRequest struct {
-	Name  [16]byte
+	Name  [unix.IFNAMSIZ]byte //const unix.InterfaceNameSize untyped int = 0x10 => 16
 	Flags uint16
 }
 
-func NewTAP(name string) (*os.File, error) {
-	file, err := os.OpenFile("/dev/net/tun", os.O_RDWR, 0)
+type Route struct {
+	Prefix *net.IPNet
+	OutIf  string
+}
+
+var routes []Route
+
+func CreateRouter(tunFileDescriptor *os.File) {
+	// while(true) to start constantly reading incoming traffic stored in /dev/tun
+	buf := make([]byte, 65535)
+	for {
+		n, err := tunFileDescriptor.Read(buf)
+		if err != nil {
+			continue
+		}
+
+		packet := buf[:n]
+
+		if len(packet) < 40 {
+			continue
+		}
+
+		// Decrement Hop Limit
+		if packet[7] <= 1 {
+			continue
+		}
+		packet[7]--
+
+		dst := net.IP(packet[24:40])
+
+		outIf := LookupRoute(dst)
+		if outIf == "" {
+			continue
+		}
+
+		/*
+			FORWARD TRAFFIC TO ANOTHER NODE
+		*/
+
+		SendPacket(outIf, packet)
+	}
+}
+
+func CreateIPv6PacketListener(tunFileDescriptor *os.File) {
+	buf := make([]byte, 65535)
+	for {
+		n, err := tunFileDescriptor.Read(buf)
+		if err != nil {
+			continue
+		}
+
+		packet := buf[:n]
+
+		payload := packet[40:]
+		log.Printf("Payload (%d bytes): % x\n", len(payload), payload)
+	}
+}
+
+func NewTUN(name string) *os.File {
+	fileDescriptor, err := os.OpenFile("/dev/net/tun", os.O_RDWR, 0)
 
 	if err != nil {
-		return nil, err
+		log.Fatalf("open /dev/net/tun failed: %v", err)
 	}
 
-	return file, nil
+	var req interfaceRequest
+	copy(req.Name[:], name)
+	req.Flags = InterfaceFlag_TUN | InterfaceFlag_NO_PI
+
+	_, _, errno := unix.Syscall(
+		unix.SYS_IOCTL,
+		fileDescriptor.Fd(),
+		uintptr(unix.TUNSETIFF),
+		uintptr(unsafe.Pointer(&req)),
+	)
+	if errno != 0 {
+		fileDescriptor.Close()
+		log.Fatalf("ioctl TUNSETIFF failed: %v", errno)
+	}
+
+	log.Println("TUN interface created: ", fileDescriptor)
+	return fileDescriptor
+}
+
+func AddRoute(cidr, outIf string) {
+	_, netw, err := net.ParseCIDR(cidr)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	routes = append(routes, Route{
+		Prefix: netw,
+		OutIf:  outIf,
+	})
+}
+
+func LookupRoute(dst net.IP) string {
+	for _, r := range routes {
+		if r.Prefix.Contains(dst) {
+			return r.OutIf
+		}
+	}
+	return ""
+}
+
+// send packet through a raw socket
+func SendPacket(ifName string, packet []byte) {
+	iface, err := net.InterfaceByName(ifName)
+	if err != nil {
+		return
+	}
+
+	fd, err := syscall.Socket(
+		syscall.AF_PACKET,
+		syscall.SOCK_RAW,
+		int(htons(0x86DD)),
+	)
+	if err != nil {
+		return
+	}
+	defer syscall.Close(fd)
+
+	sll := &syscall.SockaddrLinklayer{
+		Ifindex:  iface.Index,
+		Protocol: htons(0x86DD),
+	}
+
+	// Kernel will add L2 header automatically
+	syscall.Sendto(fd, packet, 0, sll)
+}
+
+func htons(i uint16) uint16 {
+	return (i<<8)&0xff00 | i>>8
 }


### PR DESCRIPTION
Implemented a basic gateway for tap_linux.go and added it to main.go

Line 14 @ tap_linux.go: we're gonna have to disable ipv6 forwarding because we will be doing forwarding ourselves (net.ipv6.conf.all.forwarding=0)